### PR TITLE
trust-region teacher regularization

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,9 @@ Located at `actor.self_distillation` in the config. Only active when `actor.poli
 
 - **success_reward_threshold** (float, default: `1.0`): Minimum sequence reward to be considered a successful demonstration.
 
-- **ema_update_rate** (float, default: `0.05`): EMA update rate for teacher weights.
+- **teacher_regularization** (str, default: `"ema"`): Teacher regularization mode. Options: `ema`, `trust-region`. Note: if `ema` is used, the model on the `RefWorker` is updated as an exponential moving average. `trust-region` requires `use_fused_kernels = False`.
+
+- **teacher_update_rate** (float, default: `0.05`): EMA update rate for teacher weights, or trust-region mixing coefficient.
 
 - **distillation_topk** (int | None, default: `100`): If set, use top-k logits for distillation instead of full distribution.
 

--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -98,8 +98,11 @@ self_distillation:
   # Minimum sequence reward to be considered successful
   success_reward_threshold: 0.5
 
-  # EMA update rate for teacher weights
-  ema_update_rate: 0.05 
+  # Teacher regularization method: "ema" or "trust-region"
+  teacher_regularization: ema
+
+  # EMA update rate for teacher weights, or trust-region mixing coefficient
+  teacher_update_rate: 0.05 
 
   # Maximum length of the reprompted prompt
   max_reprompt_len: 10240


### PR DESCRIPTION
Adds an alternative teacher regularization to EMA (Appendix A.1).
We introduce a new config option `self_distillation.teacher_regularization` which can be set to "ema" (preserving old behavior) or "trust-region" (alternative regularization).
Additionally renames `ema_update_rate` to `teacher_update_rate`.

The trust-region regularization can be advantageous if you want to use the RefModel for KL regularization towards the initial policy. Trust-region allows this. With EMA the RefModel is updated over time.