### PR TITLE
include system prompt & filter sciknoweval for L3 questions

### DIFF
--- a/data/load_dataset.py
+++ b/data/load_dataset.py
@@ -48,7 +48,7 @@ def load_dataset_hf(
     elif dataset_name == "tooluse":
         print("Tooluse dataset is already loaded. You can proceed to preprocess it.")
     elif dataset_name in ["Biology", "Chemistry", "Material", "Physics"]:
-        ds = load_sciknoweval(domain=dataset_name)
+        ds = load_sciknoweval(domain=dataset_name, level="L3")
     else:
         raise ValueError(f"Dataset {dataset_name} not supported.")
     ds = ds.add_column("idx", list(range(len(ds))))

--- a/data/load_dataset.py
+++ b/data/load_dataset.py
@@ -30,7 +30,7 @@ def load_dataset_hf(
     embeddings_file: str | None = None,
 ) -> Dataset:
 
-    final_columns = ["idx", "kind", "dataset", "answer", "elo", "prompt", "description", "tests", "embedding"]
+    final_columns = ["idx", "kind", "dataset", "answer", "elo", "prompt", "description", "tests", "embedding", "system"]
 
     if category == "false":
         category = None


### PR DESCRIPTION
## Summary
- Add `system` column to dataset schema to preserve system prompts
- Filter SciKnowEval datasets (Biology, Chemistry, Material, Physics) to L3 difficulty level

## Changes
1. **Dataset Schema Enhancement**
   - Added `system` to `final_columns` list in `load_dataset_hf()`

2. **SciKnowEval Filtering**
   - Restricted SciKnowEval datasets to L3 (expert-level) questions