### PR TITLE
Fix experiments/rich_feedback/run_sdpo.sh param[ema_update_rate -> teacher_update_rate]

### DIFF
--- a/experiments/rich_feedback/run_sdpo.sh
+++ b/experiments/rich_feedback/run_sdpo.sh
@@ -119,7 +119,7 @@ actor_rollout_ref.actor.self_distillation.distillation_topk=20 \
 algorithm.rollout_correction.rollout_is=token \
 actor_rollout_ref.actor.self_distillation.dont_reprompt_on_self_success=${DONTS_REPROMPT_ON_SELF_SUCCESS} \
 actor_rollout_ref.actor.self_distillation.alpha=$ALPHA \
-actor_rollout_ref.actor.self_distillation.ema_update_rate=0.01 \
+actor_rollout_ref.actor.self_distillation.teacher_update_rate=0.01 \
 actor_rollout_ref.actor.optim.lr_warmup_steps=0 \
 actor_rollout_ref.rollout.val_kwargs.n=4"
 


### PR DESCRIPTION
Hi!

Thank you for your excellent work and for providing such a useful repository.

While running the script [experiments/rich_feedback/run_sdpo.sh](https://github.com/lasgroup/SDPO/blob/main/experiments/rich_feedback/run_sdpo.sh), I encountered a configuration error related to the EMA update parameter.

The script currently overrides`actor_rollout_ref.actor.self_distillation.ema_update_rate`.

However, in the source code the corresponding field in `SelfDistillationConfig` is named: `teacher_update_rate`.

Because the configuration is structured, Hydra raises the following errors:

```
Key 'ema_update_rate' is not in struct
```
```
TypeError: SelfDistillationConfig.**init**() got an unexpected keyword argument 'ema_update_rate'

```

This PR updates the parameter name in `run_sdpo.sh` from `ema_update_rate` to `teacher_update_rate` to match the current implementation.