### PR TITLE
Fix data/load_dataset.py columns list

### DIFF
--- a/data/load_dataset.py
+++ b/data/load_dataset.py
@@ -84,6 +84,7 @@ def load_dataset_hf(
     # Add correct suffix to each description
     ds = ds.map(lambda ex: {"description": ex["description"] + f" The solution will be evaluated in a {ex['kind']} environment."})
 
+    final_columns = [c for c in final_columns if c in ds.column_names]
     ds = ds.select_columns(final_columns)
 
 


### PR DESCRIPTION
The dataset `livecodebench/code_generation_lite-v6` does not contain a `'system'` column.

When running:
```
python data/load_dataset.py --dataset_name livecodebench/code_generation_lite-v6 --output_path datasets/lcb_v6.json
```
the script fails with:
```
Traceback (most recent call last):
  File "/app/data/load_dataset.py", line 148, in <module>
    load_dataset_hf(
  File "/app/data/load_dataset.py", line 88, in load_dataset_hf
    ds = ds.select_columns(final_columns)
    ...
    raise ValueError(
ValueError: Column name ['system'] not in the dataset. Current columns in the dataset: ['kind', 'dataset', 'description', 'problem', 'tests', 'prompt', 'idx', 'embedding', 'answer', 'elo'].
```

This fix ensures that only columns present in `ds.column_names` are selected.